### PR TITLE
Rename gem to eaco-abac; refresh README for the relaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](https://semver.org/)
 
 ## Unreleased (2.0.0.beta1)
 
+### Changed
+* **Gem renamed to `eaco-abac`** — a maintained continuation of `eaco`
+  (last released 1.1.1, 2017, by ifad). The require path, `Eaco` namespace
+  and DSL are unchanged: use `gem "eaco-abac", require: "eaco"`. Project
+  home is now https://github.com/iamaestimo/eaco.
+
 ### Added
 * Active Record compatibility modules for Rails 7.0, 7.1, 7.2, 8.0 and 8.1
   (`V70`–`V81`). The adapter previously rejected any Active Record newer than

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in eaco.gemspec
+# Specify your gem's dependencies in eaco-abac.gemspec
 gemspec

--- a/PROJECT_TRACKER.md
+++ b/PROJECT_TRACKER.md
@@ -197,7 +197,33 @@ framework" (which loses a head-to-head with Pundit on simple role apps).
 - [x] ~~`coveralls` replacement~~ **DONE:** now plain `SimpleCov`. Optional future:
   wire CI to upload LCOV to a coverage service (qlty/codecov) — no gem needed.
 - [ ] When to actually tag `v2.0.0.beta1` (release workflow is in place; needs the
-  rubygems.org trusted-publisher registration first).
+  rubygems.org trusted-publisher registration first). **ON HOLD pending the
+  upstream outreach below.**
+- [ ] **⚠ BLOCKING — upstream is stirring: ifad/eaco PR #24** (discovered
+  2026-07-02). An ifad member (lleirborras) opened "Support Rails 8.1 / Ruby 4"
+  on 2026-06-19 — motivation is their internal fleet upgrade (edoc, hermeshq,
+  noobs, scriptoria depend on eaco). Open, unreviewed, unmerged as of today.
+  - **Overlap with our Phase 1:** same core compat work; their railtie fix is
+    the *identical* `app.config.to_prepare` approach (independent convergence).
+  - **They have / we don't:** a single `Modern` fallback module for AR ≥ 7.0
+    instead of per-version `V70`–`V81` copies — cleaner; adopt it later
+    regardless of outcome (logged under Phase 2 cleanup below).
+  - **We have / they don't:** `rails db:create` `NoDatabaseError` fix;
+    real-Rails-8.1-app validation; clean version floor (they keep Ruby 2.7 /
+    Rails 6.1, coveralls, yard-cucumber, Cucumber ~9.2); Cucumber 11; trusted
+    publishing release automation; README repositioning; Phase 2 ABAC roadmap;
+    stated intent of long-term community maintenance.
+  - **Risk:** ifad owns the `eaco` rubygems name. If they merge + release 2.x,
+    the "rescue of an abandoned gem" launch story collapses and `eaco-abac`
+    becomes a confusing parallel fork.
+  - **Plan (decided 2026-07-02):** comment on their PR #24 — congratulate,
+    note the identical railtie fix, offer to upstream the `db:create` fix and
+    the rest, ask about release plans and co-maintainership / gem ownership.
+    **Timebox: 2 weeks** (until ~2026-07-16). Outcomes: (a) maintainership →
+    inherit the real name, retire `eaco-abac` plan; (b) they release, we
+    contribute upstream; (c) silence → launch `eaco-abac` with the honest
+    "offered upstream first" story. Draft comment prepared; posting is
+    Aestimo's call, in his voice.
 
 ## GitHub issue sync notes (apply later when we sync)
 
@@ -231,4 +257,17 @@ framework" (which loses a head-to-head with Pundit on simple role apps).
   all three gemfiles. **Phase 1 code work fully complete.**
 - **2026-07-02 (PR):** Opened PR #5 (`main` ← `phase-1-modernization`,
   https://github.com/iamaestimo/eaco/pull/5). GitHub Actions CI green on all
-  6 matrix cells (Ruby 3.2–4.0 × Rails 7.2/8.0/8.1, PG 16).
+  6 matrix cells (Ruby 3.2–4.0 × Rails 7.2/8.0/8.1, PG 16). Merged by Aestimo.
+- **2026-07-02 (rename):** Gem renamed to `eaco-abac` (PR #6,
+  https://github.com/iamaestimo/eaco/pull/6): gemspec → `eaco-abac.gemspec`,
+  homepage/badges/links → this fork, README relaunch refresh (lineage note,
+  jsonb migration, `::Model` constant requirement, `before_filter` →
+  `before_action`). Suite re-verified green. RubyGems account created;
+  pending-trusted-publisher registration deferred (reservation expires in
+  days — create it right before merge+tag).
+- **2026-07-02 (upstream):** Discovered ifad/eaco PR #24 (Rails 8.1/Ruby 4
+  support by an ifad member, opened 2026-06-19). Beta tag put ON HOLD;
+  outreach comment drafted for Aestimo to post. See the blocking item under
+  *Open decisions*. Cleanup candidate regardless of outcome: replace our
+  per-version `V70`–`V81` compat copies with their single `Modern` fallback
+  module for AR ≥ 7.0.

--- a/PROJECT_TRACKER.md
+++ b/PROJECT_TRACKER.md
@@ -187,9 +187,13 @@ framework" (which loses a head-to-head with Pundit on simple role apps).
 - [ ] **Full Appraisal removal?** Currently trimmed Appraisals + checked-in gemfiles
   (both kept in sync). Decide whether to drop the `appraisal` dev dep entirely and
   hand-maintain gemfiles, or keep Appraisal as the generator.
-- [ ] **Repo home:** issues live on `iamaestimo/eaco`, but gemspec/README still point
-  at upstream `ifad/eaco`. Decide if this fork is the maintained home (affects
-  gemspec `homepage`, badges, README links).
+- [x] ~~**Repo home:**~~ **DECIDED (2026-07-02):** `iamaestimo/eaco` is the
+  maintained home. Gem republished as **`eaco-abac`** (the `eaco` name on
+  rubygems.org is owned by ifad; name checked available). Require path stays
+  `require "eaco"` (`gem "eaco-abac", require: "eaco"`). Gemspec renamed to
+  `eaco-abac.gemspec`, homepage/badges/README all point at the fork; README
+  carries a lineage note crediting ifad's original. First publish will claim
+  the name via a *pending trusted publisher* on rubygems.org (no API key).
 - [x] ~~`coveralls` replacement~~ **DONE:** now plain `SimpleCov`. Optional future:
   wire CI to upload LCOV to a coverage service (qlty/codecov) — no gem needed.
 - [ ] When to actually tag `v2.0.0.beta1` (release workflow is in place; needs the

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Eaco
 
-[![CI](https://github.com/ifad/eaco/actions/workflows/ci.yml/badge.svg)](https://github.com/ifad/eaco/actions/workflows/ci.yml)
-[![Maintainability](https://qlty.sh/gh/ifad/projects/eaco/maintainability.svg)](https://qlty.sh/gh/ifad/projects/eaco)
-[![Inline docs](https://inch-ci.org/github/ifad/eaco.svg?branch=master)](https://inch-ci.org/github/ifad/eaco)
-[![Gem Version](https://badge.fury.io/rb/eaco.svg)](https://badge.fury.io/rb/eaco)
+[![CI](https://github.com/iamaestimo/eaco/actions/workflows/ci.yml/badge.svg)](https://github.com/iamaestimo/eaco/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/eaco-abac.svg)](https://rubygems.org/gems/eaco-abac)
 
 Eacus, the holder of the keys of Hades, is an Attribute-Based Access Control ([ABAC](https://en.wikipedia.org/wiki/Attribute-based_access_control)) authorization
 framework for Ruby.
+
+Supports **Ruby 3.2–4.0** and **Rails 7.2–8.1**.
+
+> **Note:** the gem is published as [`eaco-abac`](https://rubygems.org/gems/eaco-abac) —
+> a maintained continuation of the original [`eaco`](https://github.com/ifad/eaco)
+> by [ifad](https://github.com/ifad), whose last release (1.1.1, 2017) supported
+> Rails up to 5. Same library, same `require "eaco"`, same DSL — modernized and
+> actively developed here.
 
 ![Eaco e Telamone][eaco-e-telamone]
 
@@ -89,22 +95,38 @@ database. Adapters are provided for PG's +jsonb+ and for CouchDB-Lucene.
 
 Add this line to your application's Gemfile:
 
-    gem 'eaco'
+```ruby
+gem "eaco-abac", require: "eaco"
+```
 
 And then execute:
 
-    $ bundle
+    $ bundle install
+
+Each authorized model needs a `jsonb` column named `acl` (PostgreSQL):
+
+```ruby
+class AddAclToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :acl, :jsonb
+  end
+end
+```
 
 ## Usage
 
-Create `config/authorization.rb` [(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/DSL)
+Create `config/authorization.rb` [(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/DSL).
+It is parsed when your app boots and re-parsed on each code reload in
+development. Reference your models with top-level constants (`::Document`) —
+the file is evaluated inside Eaco's DSL context, so a bare `Document` would
+be looked up under the `Eaco::` namespace.
 
 ```ruby
 # Defines `Document` to be an authorized resource.
 #
 # Adds Document.accessible_by and Document#allows?
 #
-authorize Document, using: :pg_jsonb do
+authorize ::Document, using: :pg_jsonb do
   roles :owner, :editor, :reader
 
   permissions do
@@ -119,7 +141,7 @@ end
 #
 # Adds User#designators
 #
-actor User do
+actor ::User do
   admin do |user|
     user.admin?
   end
@@ -132,8 +154,8 @@ actor User do
 end
 ```
 
-Given a Resource [(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/Resource)
-with an ACL [(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/ACL):
+Given a Resource [(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/Resource)
+with an ACL [(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/ACL):
 
 ```ruby
 # An example ACL
@@ -144,7 +166,7 @@ with an ACL [(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/ACL):
 => #<Document::ACL {"user:10" => :owner, "group:reviewers" => :reader}>
 ```
 
-and an Actor [(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/Actor):
+and an Actor [(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/Actor):
 
 ```ruby
 # An example Actor
@@ -217,7 +239,7 @@ Grant reader access to a group:
 ```
 
 Obtain a collection of Resources accessible by a given Actor
-[(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/Adapters):
+[(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/Adapters):
 
 ```ruby
 >> Document.accessible_by(user)
@@ -225,11 +247,11 @@ Obtain a collection of Resources accessible by a given Actor
 
 Check whether a controller action can be accessed by an user. Your
 Controller must respond to `current_user` for this to work.
-[(rdoc)](https://www.rubydoc.info/github/ifad/eaco/master/Eaco/Controller)
+[(rdoc)](https://www.rubydoc.info/github/iamaestimo/eaco/main/Eaco/Controller)
 
 ```ruby
 class DocumentsController < ApplicationController
-  before_filter :find_document
+  before_action :find_document
 
   authorize :show, [:document, :read]
   authorize :edit, [:document, :edit]
@@ -243,13 +265,13 @@ end
 
 ## Running specs
 
-You need a running postgresql 9.4 instance.
+You need a running PostgreSQL instance.
 
 Create an user and a database:
 
     $ sudo -u postgres psql
 
-    postgres=# CREATE ROLE eaco LOGIN;
+    postgres=# CREATE ROLE eaco LOGIN PASSWORD 'yourpassword';
     CREATE ROLE
 
     postgres=# CREATE DATABASE eaco OWNER eaco ENCODING 'utf8';
@@ -268,11 +290,11 @@ Run `rake`. This will run the specs and cucumber features and report coverage.
 
 Specs are run against the supported rails versions in turn. If you want to
 focus on a single release, use `appraisal rails-X.Y rake`, where `X.Y` can be
-`3.2`, `4.0`, `4.1`, `4.2`, `5.0`, `5.1`, `5.2`, `6.0`, and `6.1`.
+`7.2`, `8.0`, and `8.1`.
 
 ## Contributing
 
-1. Fork it ( https://github.com/ifad/eaco/fork )
+1. Fork it ( https://github.com/iamaestimo/eaco/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/eaco-abac.gemspec
+++ b/eaco-abac.gemspec
@@ -4,13 +4,13 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'eaco/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "eaco"
+  spec.name          = "eaco-abac"
   spec.version       = Eaco::VERSION
-  spec.authors       = ["Marcello Barnaba"]
-  spec.email         = ["vjt@openssl.it"]
+  spec.authors       = ["Aestimo K.", "Marcello Barnaba"]
+  spec.email         = ["zeros.only@proton.me"]
   spec.summary       = %q{Attribute-Based Access Control (ABAC) authorization framework for Ruby}
-  spec.description   = %q{Eaco is an ABAC authorization framework: authorization decisions live in the database as per-record ACLs (designator => role), with efficient extraction of the collection of resources accessible by an actor.}
-  spec.homepage      = "https://github.com/ifad/eaco"
+  spec.description   = %q{Eaco is an ABAC authorization framework: authorization decisions live in the database as per-record ACLs (designator => role), with efficient extraction of the collection of resources accessible by an actor. Maintained continuation of the eaco gem, modernized for Rails 7.2-8.1 and Ruby 3.2-4.0.}
+  spec.homepage      = "https://github.com/iamaestimo/eaco"
   spec.license       = "MIT"
 
   spec.required_ruby_version = ">= 3.2"
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri"      => spec.homepage,
     "source_code_uri"   => spec.homepage,
-    "changelog_uri"     => "#{spec.homepage}/blob/master/CHANGELOG.md",
+    "changelog_uri"     => "#{spec.homepage}/blob/main/CHANGELOG.md",
     "rubygems_mfa_required" => "true"
   }
 


### PR DESCRIPTION
## Summary

The `eaco` name on rubygems.org belongs to ifad (last release 1.1.1, 2017). This repo is now the maintained home, and the gem will be republished as **`eaco-abac`**. The require path, `Eaco` namespace and DSL are unchanged: `gem "eaco-abac", require: "eaco"`.

### Changes
- Gemspec renamed to `eaco-abac.gemspec`; gem name, homepage, metadata and authorship updated; description notes the continuation lineage.
- README refresh for the relaunch:
  - badges point at this repo and the `eaco-abac` gem; supported-versions line (Ruby 3.2–4.0, Rails 7.2–8.1)
  - lineage note crediting ifad's original
  - install section shows the `require:` override and the required jsonb `acl` migration
  - usage documents that `config/authorization.rb` must reference models as top-level constants (`::Document`) — found during the Rails 8.1 smoke test
  - `before_filter` → `before_action` in the controller example (removed in Rails 5.1)
  - rubydoc links and dev-setup instructions modernized
- CHANGELOG + tracker updated (repo-home/name decision resolved).

### Test plan
- [x] Gemspec loads as `eaco-abac 2.0.0.beta1`
- [x] RSpec 21/0 and Cucumber 33/33 green on rails_8.1 gemfile after the rename
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)